### PR TITLE
Enable NORMALIZE_WHITESPACE ELLIPSIS by default in docstrings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - MINICONDA_PATH=/home/travis/miniconda
   - chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
   - export PATH=$MINICONDA_PATH/bin:$PATH
-  - conda update --yes conda
+  - conda install --yes conda==4.6.14
   # create the testing environment
   - conda create -n testenv --yes python=$PYTHON_VERSION pip
   - source activate testenv

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,5 @@ description-file = README.rst
 test = pytest
 
 [tool:pytest]
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 addopts = --doctest-modules


### PR DESCRIPTION
This enables NORMALIZE_WHITESPACE ELLIPSIS sphinx directives by default in docstrings, similarly to what was recently done in scikit-learn.

Should help with test failures in https://github.com/scikit-learn-contrib/scikit-learn-extra/pull/13

Will merge on green CI.