### PR TITLE
BUG: Fix eigenpro failure on travisCI

### DIFF
--- a/sklearn_extra/kernel_methods/_eigenpro.py
+++ b/sklearn_extra/kernel_methods/_eigenpro.py
@@ -370,7 +370,7 @@ class BaseEigenPro(BaseEstimator):
             Predicted targets.
         """
         check_is_fitted(self, ["bs_", "centers_", "coef_", "was_1D_"])
-        X = np.asarray(X, dtype=np.float32)
+        X = np.asarray(X, dtype=np.float64)
 
         if len(X.shape) == 1:
             raise ValueError(

--- a/sklearn_extra/tests/test_common.py
+++ b/sklearn_extra/tests/test_common.py
@@ -13,7 +13,7 @@ from sklearn_extra.cluster import KMedoids
         Fastfood,
         KMedoids,
         _eigenpro.EigenProClassifier,
-        pytest.param(_eigenpro.EigenProRegressor, marks=pytest.mark.xfail),
+        _eigenpro.EigenProRegressor,
     ],
 )
 def test_all_estimators(Estimator, request):


### PR DESCRIPTION
A fix for https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/28 where the eigenpro regressor is failing the ci tests.

Closes https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/28