### PR TITLE
MAINT Fix minimal numpy dependency in pyproject.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools",
     "wheel",
     "cython>=0.28",
-    "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.5' and platform_system!='AIX'",
     "numpy==1.14.5; python_version=='3.6' and platform_system!='AIX'",
     "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
     "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,20 @@
 [build-system]
 # build with the oldest numpy that has pre-build wheels for Py3.7 on PyPi
-requires = ["setuptools", "wheel", "cython>=0.28", "numpy==1.14.5"]
+requires = [
+    "setuptools",
+    "wheel",
+    "cython>=0.28",
+    "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.6' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
+    # Minimum supported numpy 1.16 for AIX
+    # see https://github.com/scipy/scipy/pull/10431
+    "numpy==1.16.0; python_version=='3.5' and platform_system!='AIX'",
+    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+]
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
Closes https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/16

Fixes numpy minimal numpy dependencies in pyproject.toml to always build with the oldest supported version, similarly to how it is done in,
 - scipy: https://github.com/scipy/scipy/blob/master/pyproject.toml
 - pandas: https://github.com/pandas-dev/pandas/blob/master/pyproject.toml
 - or https://pypi.org/project/oldest-supported-numpy/

Will merge on green CI.