### PR TITLE
Drop python 35

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Dependencies
 
 scikit-learn-extra requires,
  
-- Python (>=3.5)
+- Python (>=3.6)
 - scikit-learn (>=0.21), and its dependencies
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # project-template documentation build configuration file, created by
 # sphinx-quickstart on Mon Jan 18 14:44:12 2016.
@@ -78,8 +77,8 @@ plot_gallery = True
 master_doc = "index"
 
 # General information about the project.
-project = u"scikit-learn-extra"
-copyright = u"2019, scikit-learn-extra developpers"
+project = "scikit-learn-extra"
+copyright = "2019, scikit-learn-extra developpers"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -237,8 +236,8 @@ latex_documents = [
     (
         "index",
         "project-template.tex",
-        u"project-template Documentation",
-        u"Vighnesh Birodkar",
+        "project-template Documentation",
+        "Vighnesh Birodkar",
         "manual",
     )
 ]
@@ -272,8 +271,8 @@ man_pages = [
     (
         "index",
         "project-template",
-        u"project-template Documentation",
-        [u"Vighnesh Birodkar"],
+        "project-template Documentation",
+        ["Vighnesh Birodkar"],
         1,
     )
 ]
@@ -291,8 +290,8 @@ texinfo_documents = [
     (
         "index",
         "project-template",
-        u"project-template Documentation",
-        u"Vighnesh Birodkar",
+        "project-template Documentation",
+        "Vighnesh Birodkar",
         "project-template",
         "One line description of project.",
         "Miscellaneous",
@@ -316,7 +315,7 @@ texinfo_documents = [
 # intersphinx configuration
 intersphinx_mapping = {
     "python": (
-        "https://docs.python.org/{.major}".format(sys.version_info),
+        f"https://docs.python.org/{sys.version_info.major}",
         None,
     ),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Dependencies
 
 scikit-learn-extra requires,
  
-- Python (>=3.5)
+- Python (>=3.6)
 - scikit-learn (>=0.21), and its dependencies
 
 

--- a/examples/plot_kmedoids_digits.py
+++ b/examples/plot_kmedoids_digits.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 =============================================================
 A demo of K-Medoids clustering on the handwritten digits data

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ CLASSIFIERS = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",

--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -340,9 +340,7 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
                 :n_clusters
             ]
         else:
-            raise ValueError(
-                f"init value '{self.init}' not recognized"
-            )
+            raise ValueError(f"init value '{self.init}' not recognized")
 
         return medoids
 

--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """K-medoids clustering"""
 
 # Authors: Timo Erkkilä <timo.erkkila@gmail.com>
@@ -342,7 +341,7 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
             ]
         else:
             raise ValueError(
-                "init value '{init}' not recognized".format(init=self.init)
+                f"init value '{self.init}' not recognized"
             )
 
         return medoids


### PR DESCRIPTION
Closes #56 

Python 3.5 reached EOL and similar decision was done in scikit-learn earlier.

Shouldn't be too controversial, merging on green CI.