### PR TITLE
MNT scikit-learn 0.23 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Dependencies
 scikit-learn-extra requires,
  
 - Python (>=3.6)
-- scikit-learn (>=0.21), and its dependencies
+- scikit-learn (>=0.22), and its dependencies
 
 
 User installation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
         python.version: '3.6'
         NUMPY_VERSION: "1.13.3"
         SCIPY_VERSION: "0.19.1"
-        SKLEARN_VERSION: "0.21.2"
+        SKLEARN_VERSION: "0.22.2post1"
       Python37:
         python.version: '3.7'
         NUMPY_VERSION: "1.16.5"
@@ -63,7 +63,7 @@ jobs:
         python.version: '3.6'
         NUMPY_VERSION: "1.13.3"
         SCIPY_VERSION: "0.19.1"
-        SKLEARN_VERSION: "0.21.2"
+        SKLEARN_VERSION: "0.22.2post1"
       Python37:
         python.version: '3.7'
         NUMPY_VERSION: "1.16.5"
@@ -115,7 +115,7 @@ jobs:
         python.version: '3.6'
         NUMPY_VERSION: "1.13.3"
         SCIPY_VERSION: "1.0.1"
-        SKLEARN_VERSION: "0.21.2"
+        SKLEARN_VERSION: "0.22.2post1"
       Python38:
         python_ver: '38'
         python.version: '3.8'

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,39 @@
+import sys
+from distutils.version import LooseVersion
+import sklearn
+
+import pytest
+from _pytest.doctest import DoctestItem
+
+
+def pytest_collection_modifyitems(config, items):
+
+    # numpy changed the str/repr formatting of numpy arrays in 1.14. We want to
+    # run doctests only for numpy >= 1.14.
+    skip_doctests = False
+    try:
+        import numpy as np
+
+        if LooseVersion(np.__version__) < LooseVersion("1.14") or LooseVersion(
+            sklearn.__version__
+        ) < LooseVersion("0.23.0"):
+            reason = (
+                "doctests are only run for numpy >= 1.14 "
+                "and scikit-learn >=0.23.0"
+            )
+            skip_doctests = True
+        elif sys.platform.startswith("win32"):
+            reason = (
+                "doctests are not run for Windows because numpy arrays "
+                "repr is inconsistent across platforms."
+            )
+            skip_doctests = True
+    except ImportError:
+        pass
+
+    if skip_doctests:
+        skip_marker = pytest.mark.skip(reason=reason)
+
+        for item in items:
+            if isinstance(item, DoctestItem):
+                item.add_marker(skip_marker)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,7 +7,7 @@ Dependencies
 scikit-learn-extra requires,
  
 - Python (>=3.6)
-- scikit-learn (>=0.21), and its dependencies
+- scikit-learn (>=0.22), and its dependencies
 
 
 User installation

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ URL = "https://github.com/scikit-learn-contrib/scikit-learn-extra"
 LICENSE = "new BSD"
 DOWNLOAD_URL = "https://github.com/scikit-learn-contrib/scikit-learn-extra"
 VERSION = __version__  # noqa
-INSTALL_REQUIRES = ["numpy>=1.13.3", "scipy>=0.19.1", "scikit-learn>=0.21.0"]
+INSTALL_REQUIRES = ["numpy>=1.13.3", "scipy>=0.19.1", "scikit-learn>=0.22.0"]
 CLASSIFIERS = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",

--- a/sklearn_extra/kernel_approximation/_fastfood.py
+++ b/sklearn_extra/kernel_approximation/_fastfood.py
@@ -1,5 +1,6 @@
 # License: BSD 3 clause
 
+from math import sqrt
 import numpy as np
 from scipy.stats import chi
 
@@ -56,7 +57,7 @@ class Fastfood(BaseEstimator, TransformerMixin):
 
     def __init__(
         self,
-        sigma=np.sqrt(1 / 2),
+        sigma=sqrt(1 / 2),
         n_components=100,
         tradeoff_mem_accuracy="accuracy",
         random_state=None,

--- a/sklearn_extra/kernel_approximation/test_fastfood.py
+++ b/sklearn_extra/kernel_approximation/test_fastfood.py
@@ -1,8 +1,7 @@
 import pytest
 import numpy as np
 
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 from sklearn.metrics.pairwise import rbf_kernel
 
 from sklearn_extra.kernel_approximation import Fastfood
@@ -28,7 +27,7 @@ Y /= Y.sum(axis=1)[:, np.newaxis]
 def test_fastfood_enforce_dimensionality_constraint(message, input_, expected):
     d, n = input_
     output = Fastfood._enforce_dimensionality_constraints(d, n)
-    assert_equal(expected, output, message)
+    assert expected == output, message
 
 
 def test_fastfood():

--- a/sklearn_extra/kernel_methods/_eigenpro.py
+++ b/sklearn_extra/kernel_methods/_eigenpro.py
@@ -394,10 +394,12 @@ class BaseEigenPro(BaseEstimator):
         return Y
 
     def _get_tags(self):
-        return {"multioutput": True}
+        tags = super()._get_tags()
+        tags['multioutput'] = True
+        return tags
 
 
-class EigenProRegressor(BaseEigenPro, RegressorMixin):
+class EigenProRegressor(RegressorMixin, BaseEigenPro):
     """Regression using EigenPro iteration.
 
     Train least squared kernel regression model with mini-batch EigenPro
@@ -470,9 +472,7 @@ class EigenProRegressor(BaseEigenPro, RegressorMixin):
     >>> y_train = rng.randn(n_samples, n_targets)
     >>> rgs = EigenProRegressor(n_epoch=3, gamma=.5, subsample_size=50)
     >>> rgs.fit(x_train, y_train)
-    EigenProRegressor(batch_size='auto', coef0=1, degree=3, gamma=0.5, kernel='rbf',
-                      kernel_params=None, n_components=1000, n_epoch=3,
-                      random_state=None, subsample_size=50)
+    EigenProRegressor(gamma=0.5, n_epoch=3, subsample_size=50)
     >>> y_pred = rgs.predict(x_train)
     >>> loss = np.mean(np.square(y_train - y_pred))
     """
@@ -510,7 +510,7 @@ class EigenProRegressor(BaseEigenPro, RegressorMixin):
         return self._raw_predict(X)
 
 
-class EigenProClassifier(BaseEigenPro, ClassifierMixin):
+class EigenProClassifier(ClassifierMixin, BaseEigenPro):
     """Classification using EigenPro iteration.
 
     Train least squared kernel classification model with mini-batch EigenPro
@@ -584,9 +584,7 @@ class EigenProClassifier(BaseEigenPro, ClassifierMixin):
     >>> y_train = rng.randint(n_targets, size=n_samples)
     >>> rgs = EigenProClassifier(n_epoch=3, gamma=.01, subsample_size=50)
     >>> rgs.fit(x_train, y_train)
-    EigenProClassifier(batch_size='auto', coef0=1, degree=3, gamma=0.01,
-                       kernel='rbf', kernel_params=None, n_components=1000,
-                       n_epoch=3, random_state=None, subsample_size=50)
+    EigenProClassifier(gamma=0.01, n_epoch=3, subsample_size=50)
     >>> y_pred = rgs.predict(x_train)
     >>> loss = np.mean(y_train != y_pred)
     """

--- a/sklearn_extra/kernel_methods/_eigenpro.py
+++ b/sklearn_extra/kernel_methods/_eigenpro.py
@@ -395,7 +395,7 @@ class BaseEigenPro(BaseEstimator):
 
     def _get_tags(self):
         tags = super()._get_tags()
-        tags['multioutput'] = True
+        tags["multioutput"] = True
         return tags
 
 

--- a/sklearn_extra/kernel_methods/tests/test_eigenpro.py
+++ b/sklearn_extra/kernel_methods/tests/test_eigenpro.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from sklearn.datasets import make_regression, make_classification
-from sklearn.utils.testing import assert_allclose
+from numpy.testing import assert_allclose
 from sklearn_extra.kernel_methods import EigenProRegressor, EigenProClassifier
 
 import pytest

--- a/sklearn_extra/tests/test_common.py
+++ b/sklearn_extra/tests/test_common.py
@@ -7,17 +7,15 @@ from sklearn_extra.cluster import KMedoids
 
 ALL_ESTIMATORS = [Fastfood, KMedoids, EigenProClassifier, EigenProRegressor]
 
-if hasattr(estimator_checks, "parametrize_with_checks"):
-    # Common tests are only run on scikit-learn 0.22+
 
-    @estimator_checks.parametrize_with_checks(ALL_ESTIMATORS)
-    def test_all_estimators(estimator, check, request):
-        # TODO: fix this common test failure cf #41
-        if isinstance(
-            estimator, EigenProClassifier
-        ) and "function check_classifier_multioutput" in str(check):
-            request.applymarker(
-                pytest.mark.xfail(run=False, reason="See issue #41")
-            )
+@estimator_checks.parametrize_with_checks([cls() for cls in ALL_ESTIMATORS])
+def test_all_estimators(estimator, check, request):
+    # TODO: fix this common test failure cf #41
+    if isinstance(
+        estimator, EigenProClassifier
+    ) and "function check_classifier_multioutput" in str(check):
+        request.applymarker(
+            pytest.mark.xfail(run=False, reason="See issue #41")
+        )
 
-        return check(estimator)
+    return check(estimator)

--- a/sklearn_extra/utils/tests/test_fht.py
+++ b/sklearn_extra/utils/tests/test_fht.py
@@ -1,8 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 from scipy.linalg import hadamard
-
-from sklearn.utils.testing import assert_raises
+import pytest
 
 from sklearn_extra.utils._cyfht import fht as cyfht
 from sklearn_extra.utils._cyfht import fht2 as cyfht2
@@ -36,5 +35,9 @@ def test_numerical_fuzzing_fht2():
 
 
 def test_exception_when_input_not_power_two():
-    assert_raises(ValueError, cyfht, np.zeros(9, dtype=np.float64))
-    assert_raises(ValueError, cyfht2, np.zeros((2, 9), dtype=np.float64))
+    msg = "Length of input for fht must be a power of two"
+    with pytest.raises(ValueError, match=msg):
+        cyfht(np.zeros(9, dtype=np.float64))
+    msg = "Length of rows for fht2 must be a power of two"
+    with pytest.raises(ValueError, match=msg):
+        cyfht2(np.zeros((2, 9), dtype=np.float64))


### PR DESCRIPTION
Fix a few tests that got broken by the scikit-learn 0.23 mostly due to the use of deprecated utils in testing.

Also bump the minimal supported scikit-learn version by 1 to 0.22 per https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/19

Will merge on green CI as this is currently affecting other PRs.