### PR TITLE
MAINT Only trigger wheels building manually or on releases

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,6 +1,17 @@
 name: build_wheels
 
-on: [push, pull_request]
+on:
+  # push
+  # pull_request
+  release:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Manually trigger wheel build in Github UI'
+        required: true
+
 
 jobs:
   build_wheels:


### PR DESCRIPTION
I don't think it's necessary to build wheels and test all the build matrix (OS x python versions) in Azure pipelines for each PR or commit on master. The tests run in Azure pipelines (which also include a range of OSs and Python versions) should be enough.

Building release wheels only on releases and manually before the release to test should be enough. This switches the Github actions triggers accordingly.