### PR TITLE
Fix CircleCI documentation CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  python3:
+  documentation:
     docker:
       - image: circleci/python:3.7.6
     steps:
@@ -50,5 +50,5 @@ workflows:
   version: 2
   build-doc-and-deploy:
     jobs:
-      - python3
+      - documentation
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,9 @@ jobs:
             chmod +x miniconda.sh && ./miniconda.sh -b -p ~/miniconda
             export PATH="~/miniconda/bin:$PATH"
             conda update --yes --quiet conda
-            conda create -n testenv --yes --quiet python=3
+            conda create -n testenv --yes --quiet python=3.7
             source activate testenv
-            conda install --yes pip numpy scipy scikit-learn matplotlib sphinx sphinx_rtd_theme numpydoc pillow cython nomkl
-            pip install sphinx-gallery
-            pip install .
+            pip install ".[docs]"
             cd doc
             make html
       - store_artifacts:

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,6 +1,0 @@
-sphinx
-scikit-learn>=0.20
-cython
-pillow
-sphinx_rtd_theme
-numpydoc


### PR DESCRIPTION
Trying to fix the segfault we currently seeing when running  the examples in CircleCI.

**Edit:** I can't reproduce it locally, and the documentation builds fine on readthedocs so it might have something to do with conda packages.