### PR TITLE
FIX initialization build on kmedoids

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   documentation:
     docker:
-      - image: circleci/python:3.7.6
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run:
@@ -12,7 +12,7 @@ jobs:
             chmod +x miniconda.sh && ./miniconda.sh -b -p ~/miniconda
             export PATH="~/miniconda/bin:$PATH"
             conda update --yes --quiet conda
-            conda create -n testenv --yes --quiet python=3.7
+            conda create -n testenv --yes --quiet python=3.8
             source activate testenv
             pip install ".[docs]"
             cd doc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
   documentation:
     docker:
       - image: circleci/python:3.8
+    environment:
+      - OMP_NUM_THREADS: 2
+      - MKL_NUM_THREADS: 2
     steps:
       - checkout
       - run:

--- a/sklearn_extra/cluster/_k_medoids_helper.pyx
+++ b/sklearn_extra/cluster/_k_medoids_helper.pyx
@@ -84,7 +84,7 @@ def _build( floating[:, :] D, int n_clusters):
 
     cdef floating[:] Dj = D[medoid_idxs[0]].copy()
     cdef floating cost_change
-    cdef (int, int) new_medoid
+    cdef (int, int) new_medoid = (0,0)
     cdef floating cost_change_max
 
     for _ in range(n_clusters -1):

--- a/sklearn_extra/cluster/_k_medoids_helper.pyx
+++ b/sklearn_extra/cluster/_k_medoids_helper.pyx
@@ -74,7 +74,7 @@ def _build( floating[:, :] D, int n_clusters):
 
     cdef int[:] medoid_idxs = np.zeros(n_clusters, dtype = np.intc)
     cdef int sample_size = len(D)
-    cdef int[:] not_medoid_idxs = np.zeros(sample_size, dtype = np.intc)
+    cdef int[:] not_medoid_idxs = np.arange(sample_size, dtype = np.intc)
     cdef int i, j,  id_i, id_j
 
     medoid_idxs[0] = np.argmin(np.sum(D,axis=0))
@@ -84,7 +84,7 @@ def _build( floating[:, :] D, int n_clusters):
 
     cdef floating[:] Dj = D[medoid_idxs[0]].copy()
     cdef floating cost_change
-    cdef (int, int) new_medoid = (medoid_idxs[0], 0)
+    cdef (int, int) new_medoid
     cdef floating cost_change_max
 
     for _ in range(n_clusters -1):

--- a/sklearn_extra/cluster/tests/test_k_medoids.py
+++ b/sklearn_extra/cluster/tests/test_k_medoids.py
@@ -5,9 +5,10 @@ from unittest import mock
 from scipy.sparse import csc_matrix
 import pytest
 
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_iris, fetch_20newsgroups_vectorized
 from sklearn.metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
-from sklearn.metrics.pairwise import euclidean_distances
+from sklearn.metrics.pairwise import euclidean_distances, cosine_distances
+
 from numpy.testing import assert_allclose, assert_array_equal
 
 from sklearn_extra.cluster import KMedoids
@@ -331,3 +332,18 @@ def test_kmedoids_on_sparse_input():
     labels = model.fit_predict(X)
     assert len(labels) == 2
     assert_array_equal(labels, model.labels_)
+
+
+# Test the build initialization.
+def test_build():
+    X, y = fetch_20newsgroups_vectorized(return_X_y=True)
+    # Select only the first 1000 samples
+    X = X[:500]
+    y = y[:500]
+    # Precompute cosine distance matrix
+    diss = cosine_distances(X)
+    # run build
+    ske = KMedoids(20, "precomputed", init="build", max_iter=0)
+    ske.fit(diss)
+    assert ske.inertia_ <= 230
+    assert len(np.unique(ske.labels_)) == 20


### PR DESCRIPTION
Fix typo in cython build initialization.

Answer to #90 

Result :
```
import sklearn, numpy
import sklearn_extra.cluster

# Data set 20news
import sklearn.datasets
X, y = sklearn.datasets.fetch_20newsgroups_vectorized(return_X_y=True)
X, y = sklearn.utils.shuffle((X, y), random_state=1)

# Precompute cosine distance matrix
import sklearn.metrics.pairwise
diss = sklearn.metrics.pairwise.cosine_distances(X)

# run PAM from scikit-learn-extra
ske = sklearn_extra.cluster.KMedoids(20, "precomputed", method="pam", init="build")
ske.fit(diss)
print("n_iter: ", ske.n_iter_)
print("inertia: ",ske.inertia_)
> n_iter:  1
> inertia:  4994.733982868267

```