### PR TITLE
CI Use versions of numpy and scipy in Python 3.8 CI with binary wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,8 @@ jobs:
         SKLEARN_VERSION: "0.22.2post1"
       Python38:
         python.version: '3.8'
-        NUMPY_VERSION: "1.16.5"
-        SCIPY_VERSION: "1.1.0"
+        NUMPY_VERSION: "1.19.4"
+        SCIPY_VERSION: "1.4.1"
         SKLEARN_VERSION: "0.23.2"
       Python39:
         python.version: '3.9'


### PR DESCRIPTION
Currently the version of numpy and scipy specified in the Python38 build don't have binary wheels, which means that we re-built them from sources which takes a long time.

This bumps those versions slightly to use binary wheels from PyPi instead which should make CI faster.