### PR TITLE
FIX huber estimator problem

### DIFF
--- a/sklearn_extra/robust/mean_estimators.py
+++ b/sklearn_extra/robust/mean_estimators.py
@@ -122,7 +122,6 @@ def huber(X, c=1.35, T=20):
         mask = np.abs(x) <= c
         res[mask] = 1
         res[~mask] = (c / np.abs(x[~mask]))
-        res[~np.isfinite(x)] = 0
         return res
 
     # Run the iterative reweighting algorithm to compute M-estimator.

--- a/sklearn_extra/robust/mean_estimators.py
+++ b/sklearn_extra/robust/mean_estimators.py
@@ -121,7 +121,7 @@ def huber(X, c=1.35, T=20):
         res = np.zeros(len(x))
         mask = np.abs(x) <= c
         res[mask] = 1
-        res[~mask] = (c / np.abs(x[~mask]))
+        res[~mask] = c / np.abs(x[~mask])
         return res
 
     # Run the iterative reweighting algorithm to compute M-estimator.

--- a/sklearn_extra/robust/mean_estimators.py
+++ b/sklearn_extra/robust/mean_estimators.py
@@ -121,7 +121,7 @@ def huber(X, c=1.35, T=20):
         res = np.zeros(len(x))
         mask = np.abs(x) <= c
         res[mask] = 1
-        res[~mask] = (c / np.abs(x))[~mask]
+        res[~mask] = (c / np.abs(x[~mask]))
         res[~np.isfinite(x)] = 0
         return res
 

--- a/sklearn_extra/robust/tests/test_mean_estimators.py
+++ b/sklearn_extra/robust/tests/test_mean_estimators.py
@@ -1,5 +1,5 @@
 import numpy as np
-import warnings
+import pytest
 
 from sklearn_extra.robust.mean_estimators import median_of_means, huber
 
@@ -26,11 +26,6 @@ def test_mom():
 
 def test_huber():
     X = np.hstack([np.zeros(90), np.ones(10)])
-    error = False
-    with warnings.catch_warnings():
-        warnings.filterwarnings("error")
-        try:
-            huber(X)
-        except Warning as e:
-            error = True
-    assert ~error
+    with pytest.warns(None) as record:
+        huber(X)
+    assert len(record) == 0

--- a/sklearn_extra/robust/tests/test_mean_estimators.py
+++ b/sklearn_extra/robust/tests/test_mean_estimators.py
@@ -33,4 +33,4 @@ def test_huber():
             huber(X)
         except Warning as e:
             error = True
-    assert error
+    assert ~error

--- a/sklearn_extra/robust/tests/test_mean_estimators.py
+++ b/sklearn_extra/robust/tests/test_mean_estimators.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 from sklearn_extra.robust.mean_estimators import median_of_means, huber
 
@@ -21,3 +22,15 @@ def test_mom():
         sample_cor = sample
         sample_cor[:num_out] = np.inf
         assert np.abs(median_of_means(sample_cor, num_out, rng)) < 2
+
+        
+def test_huber():
+    X = np.hstack([np.zeros(90), np.ones(10)])
+    error = False
+    with warnings.catch_warnings():
+        warnings.filterwarnings('error')
+        try:
+            huber(X)
+        except Warning as e:
+            error = True
+    assert error

--- a/sklearn_extra/robust/tests/test_mean_estimators.py
+++ b/sklearn_extra/robust/tests/test_mean_estimators.py
@@ -23,12 +23,12 @@ def test_mom():
         sample_cor[:num_out] = np.inf
         assert np.abs(median_of_means(sample_cor, num_out, rng)) < 2
 
-        
+
 def test_huber():
     X = np.hstack([np.zeros(90), np.ones(10)])
     error = False
     with warnings.catch_warnings():
-        warnings.filterwarnings('error')
+        warnings.filterwarnings("error")
         try:
             huber(X)
         except Warning as e:


### PR DESCRIPTION
Fix a bug in PR #78, 
bug due to a possible division by zero with the new mask syntax for Huber estimator computation. 
It didn't impact the result due to a redundant check but now it is cleaner.
I also added a regression test here.

Should be included in 0.2.0, see issue #96 