### PR TITLE
MAINT Use RTD PR integration for rendering docs instead of CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,6 @@
 version: 2
 
 jobs:
-  documentation:
-    docker:
-      - image: circleci/python:3.8
-    environment:
-      - OMP_NUM_THREADS: 2
-      - MKL_NUM_THREADS: 2
-    steps:
-      - checkout
-      - run:
-          command: |
-            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-            chmod +x miniconda.sh && ./miniconda.sh -b -p ~/miniconda
-            export PATH="~/miniconda/bin:$PATH"
-            conda update --yes --quiet conda
-            conda create -n testenv --yes --quiet python=3.8
-            source activate testenv
-            pip install ".[docs]"
-            cd doc
-            make html
-      - store_artifacts:
-          path: doc/_build/html
-          destination: doc
-      - store_artifacts:
-          path: ~/log.txt
-      - persist_to_workspace:
-          root: doc/_build/html
-          paths: .
-      - attach_workspace:
-          at: doc/_build/html
-      - run: ls -ltrh doc/_build/html
-    filters:
-      branches:
-        ignore: gh-pages
-
   lint:
     docker:
       - image: circleci/python:3.7.6
@@ -53,5 +19,4 @@ workflows:
   version: 2
   build-doc-and-deploy:
     jobs:
-      - documentation
       - lint


### PR DESCRIPTION
This replaces documentation visualization in PRs using CircleCI with PR integration from readthedocs https://docs.readthedocs.io/en/stable/pull-requests.html  Since we use ReadTheDocs for the documentation.

It's simpler and also garantees that if it passed on a PR it will also be able to be deployed as documentation, which is not the case when building in CircleCI