### PR TITLE
MAINT Increment min scikit-learn version to 0.23.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Dependencies
 scikit-learn-extra requires,
  
 - Python (>=3.6)
-- scikit-learn (>=0.22), and its dependencies
+- scikit-learn (>=0.23), and its dependencies
 
 
 User installation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,17 +9,17 @@ jobs:
         python.version: '3.6'
         NUMPY_VERSION: "1.13.3"
         SCIPY_VERSION: "0.19.1"
-        SKLEARN_VERSION: "0.22.2post1"
+        SKLEARN_VERSION: "0.23.0"
       Python37:
         python.version: '3.7'
         NUMPY_VERSION: "1.16.5"
         SCIPY_VERSION: "1.1.0"
-        SKLEARN_VERSION: "0.22.2post1"
+        SKLEARN_VERSION: "0.23.2"
       Python38:
         python.version: '3.8'
         NUMPY_VERSION: "1.19.4"
         SCIPY_VERSION: "1.4.1"
-        SKLEARN_VERSION: "0.23.2"
+        SKLEARN_VERSION: "0.24.1"
       Python39:
         python.version: '3.9'
         NUMPY_VERSION: "1.19.4"
@@ -74,12 +74,12 @@ jobs:
         python.version: '3.6'
         NUMPY_VERSION: "1.13.3"
         SCIPY_VERSION: "0.19.1"
-        SKLEARN_VERSION: "0.22.2post1"
+        SKLEARN_VERSION: "0.23.2"
       Python37:
         python.version: '3.7'
         NUMPY_VERSION: "1.16.5"
         SCIPY_VERSION: "1.1.0"
-        SKLEARN_VERSION: "0.22.2post1"
+        SKLEARN_VERSION: "0.24.1"
       Python38:
         python.version: '3.8'
         SKLEARN_VERSION: "*"
@@ -131,13 +131,13 @@ jobs:
         python.version: '3.6'
         NUMPY_VERSION: "1.13.3"
         SCIPY_VERSION: "1.0.1"
-        SKLEARN_VERSION: "0.22.2post1"
+        SKLEARN_VERSION: "0.23.2"
       Python38:
         python_ver: '38'
         python.version: '3.8'
         NUMPY_VERSION: "1.18.2"
         SCIPY_VERSION: "1.4.1"
-        SKLEARN_VERSION: "0.22.2post1"
+        SKLEARN_VERSION: "0.24.1"
   variables:
     OMP_NUM_THREADS: '2'
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,7 +7,7 @@ Dependencies
 scikit-learn-extra requires,
  
 - Python (>=3.6)
-- scikit-learn (>=0.22), and its dependencies
+- scikit-learn (>=0.23), and its dependencies
 
 
 User installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,15 @@
 [build-system]
-# build with the oldest numpy that has pre-build wheels for Py3.7 on PyPi
+# Minimum requirements for the build system to execute.
 requires = [
     "setuptools",
     "wheel",
-    "cython>=0.28",
-    "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
-    "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
-    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
-    # Minimum supported numpy 1.16 for AIX
-    # see https://github.com/scipy/scipy/pull/10431
-    "numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+    "Cython>=0.28.5",
+
+    # use oldest-supported-numpy which provides the oldest numpy version with
+    # wheels on PyPI
+    #
+    # see: https://github.com/scipy/oldest-supported-numpy/blob/master/setup.cfg
+    "oldest-supported-numpy"
 ]
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,11 @@ DISTNAME = "scikit-learn-extra"
 DESCRIPTION = "A set of tools for scikit-learn."
 with codecs.open("README.rst", encoding="utf-8-sig") as f:
     LONG_DESCRIPTION = f.read()
-MAINTAINER = "G. Lemaitre"
-MAINTAINER_EMAIL = "g.lemaitre58@gmail.com"
 URL = "https://github.com/scikit-learn-contrib/scikit-learn-extra"
 LICENSE = "new BSD"
 DOWNLOAD_URL = "https://github.com/scikit-learn-contrib/scikit-learn-extra"
 VERSION = __version__  # noqa
-INSTALL_REQUIRES = ["numpy>=1.13.3", "scipy>=0.19.1", "scikit-learn>=0.22.0"]
+INSTALL_REQUIRES = ["numpy>=1.13.3", "scipy>=0.19.1", "scikit-learn>=0.23.0"]
 CLASSIFIERS = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
@@ -41,6 +39,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 EXTRAS_REQUIRE = {
@@ -91,8 +90,6 @@ args = {
 
 setup(
     name=DISTNAME,
-    maintainer=MAINTAINER,
-    maintainer_email=MAINTAINER_EMAIL,
     description=DESCRIPTION,
     license=LICENSE,
     url=URL,
@@ -104,5 +101,6 @@ setup(
     packages=find_packages(),
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
+    python_requires=">=3.6",
     **args
 )


### PR DESCRIPTION
Bump minimum supported scikit-learn version to 0.23.0 as discussed in https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/19


This would correspond to 2 supported version while in https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/19 we discussed only supporting 1, in this case however there doesn't seem to be much cost to keep 2. We can always reduce it later to 1.

Also other minor fixes to setup.py and pyproject.toml inspired by the scikit-learn setup.