### PR TITLE
MAINT Fix long description format in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(ver_file) as f:
 
 DISTNAME = "scikit-learn-extra"
 DESCRIPTION = "A set of tools for scikit-learn."
-with codecs.open("README.rst", encoding="utf-8-sig") as f:
+with codecs.open("README.rst", encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 URL = "https://github.com/scikit-learn-contrib/scikit-learn-extra"
 LICENSE = "new BSD"
@@ -91,6 +91,7 @@ args = {
 setup(
     name=DISTNAME,
     description=DESCRIPTION,
+    long_description_content_type="text/x-rst",
     license=LICENSE,
     url=URL,
     version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
 #! /usr/bin/env python
-"""A template for scikit-learn compatible packages."""
-
-import codecs
 import os
 
 from setuptools import find_packages, setup, Extension
@@ -18,7 +15,7 @@ with open(ver_file) as f:
 
 DISTNAME = "scikit-learn-extra"
 DESCRIPTION = "A set of tools for scikit-learn."
-with codecs.open("README.rst", encoding="utf-8") as f:
+with open("README.rst", encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 URL = "https://github.com/scikit-learn-contrib/scikit-learn-extra"
 LICENSE = "new BSD"


### PR DESCRIPTION
So far accepted PyPi all wheels except for Windows wheels which were rejected with,
```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
```
I fixed a few warnings raised by `twine check` https://github.com/pypa/warehouse/issues/5890#issuecomment-494868157 but I guess the issue must have been the encoding. Trying to fix and re-upload.