### PR TITLE
FIX `_estimator_type` in robust estimators

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 Unreleased
 ----------
-*April 14, 2021*
+*April 17, 2021*
 
 - Fix `_estimator_type` for :class:`~sklearn_extra.robust.RobustWeightedClassifier`,
   :class:`~sklearn_extra.robust.RobustWeightedRegressor` and

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,12 +3,10 @@ Changelog
 
 Unreleased
 ----------
-*April 17, 2021*
 
-- Fix `_estimator_type` for :class:`~sklearn_extra.robust.RobustWeightedClassifier`,
-  :class:`~sklearn_extra.robust.RobustWeightedRegressor` and
-  :class:`~sklearn_extra.robust.RobustWeightedKMeans` estimators.
-
+- Fix `_estimator_type` for :class:`~sklearn_extra.robust` estimators. Fix
+  misbehavior of :class:sklearn.model_selection.cross_val_score and
+  :class:sklearn.grid_search.GridSearchCV for :class:`~sklearn_extra.robust.RobustWeightedClassifier`
 
 Version 0.2.0
 -------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+*April 14, 2021*
+
+- Fix `_estimator_type` for :class:`~sklearn_extra.robust.RobustWeightedClassifier`,
+  :class:`~sklearn_extra.robust.RobustWeightedRegressor` and
+  :class:`~sklearn_extra.robust.RobustWeightedKMeans` estimators.
+
 
 Version 0.2.0
 -------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,8 +5,8 @@ Unreleased
 ----------
 
 - Fix `_estimator_type` for :class:`~sklearn_extra.robust` estimators. Fix
-  misbehavior of :class:sklearn.model_selection.cross_val_score and
-  :class:sklearn.grid_search.GridSearchCV for :class:`~sklearn_extra.robust.RobustWeightedClassifier`
+  misbehavior of scikit-learn's :class:`~sklearn.model_selection.cross_val_score` and
+  :class:`~sklearn.grid_search.GridSearchCV` for :class:`~sklearn_extra.robust.RobustWeightedClassifier`
 
 Version 0.2.0
 -------------

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -790,6 +790,8 @@ class RobustWeightedClassifier(BaseEstimator, ClassifierMixin):
             sgd_args = self.sgd_args
 
         # Define the base estimator
+        X, y = self._validate_data(X, y, y_numeric=False)
+
         base_robust_estimator_ = _RobustWeightedEstimator(
             SGDClassifier(**sgd_args, eta0=self.eta0),
             weighting=self.weighting,
@@ -1099,6 +1101,8 @@ class RobustWeightedRegressor(BaseEstimator, RegressorMixin):
 
         # Define the base estimator
 
+        X, y = self._validate_data(X, y, y_numeric=True)
+
         self.base_estimator_ = _RobustWeightedEstimator(
             SGDRegressor(**sgd_args, eta0=self.eta0),
             weighting=self.weighting,
@@ -1342,14 +1346,9 @@ class RobustWeightedKMeans(BaseEstimator, ClusterMixin):
             kmeans_args = {}
         else:
             kmeans_args = self.kmeans_args
-        X = check_array(
-            X,
-            accept_sparse="csr",
-            dtype=[np.float64, np.float32],
-            order="C",
-            accept_large_sparse=False,
-        )
-
+        X = self._validate_data(X, accept_sparse='csr',
+                                dtype=[np.float64, np.float32],
+                                order='C', accept_large_sparse=False)
         self.base_estimator_ = _RobustWeightedEstimator(
             MiniBatchKMeans(
                 self.n_clusters,

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -874,9 +874,6 @@ class RobustWeightedClassifier(BaseEstimator, ClassifierMixin):
     def _predict_proba(self, X):
         return self.base_estimator_.predict_proba(X)
 
-    @property
-    def _estimator_type(self):
-        return self.base_estimator._estimator_type
 
     def score(self, X, y=None):
         """Returns the score on the given data, using
@@ -1142,10 +1139,6 @@ class RobustWeightedRegressor(BaseEstimator, RegressorMixin):
         check_is_fitted(self, attributes=["base_estimator_"])
         return self.base_estimator_.predict(X)
 
-    @property
-    def _estimator_type(self):
-        return self.base_estimator._estimator_type
-
     def score(self, X, y=None):
         """Returns the score on the given data, using
         ``base_estimator_.score``.
@@ -1403,10 +1396,6 @@ class RobustWeightedKMeans(BaseEstimator, ClusterMixin):
 
         check_is_fitted(self, attributes=["base_estimator_"])
         return self.base_estimator_.predict(X)
-
-    @property
-    def _estimator_type(self):
-        return self.base_estimator._estimator_type
 
     def score(self, X, y=None):
         """Returns the score on the given data, using

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -874,7 +874,6 @@ class RobustWeightedClassifier(BaseEstimator, ClassifierMixin):
     def _predict_proba(self, X):
         return self.base_estimator_.predict_proba(X)
 
-
     def score(self, X, y=None):
         """Returns the score on the given data, using
         ``base_estimator_.score``.

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -1346,9 +1346,13 @@ class RobustWeightedKMeans(BaseEstimator, ClusterMixin):
             kmeans_args = {}
         else:
             kmeans_args = self.kmeans_args
-        X = self._validate_data(X, accept_sparse='csr',
-                                dtype=[np.float64, np.float32],
-                                order='C', accept_large_sparse=False)
+        X = self._validate_data(
+            X,
+            accept_sparse="csr",
+            dtype=[np.float64, np.float32],
+            order="C",
+            accept_large_sparse=False,
+        )
         self.base_estimator_ = _RobustWeightedEstimator(
             MiniBatchKMeans(
                 self.n_clusters,


### PR DESCRIPTION
In the robust estimators, the estimator type is only defined after a fit. 
This can cause bugs when using the estimators for cross-validation in sklearn.
This fixes the estimator types.