### PR TITLE
MAINT Add pre-commit setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: |
               black --check examples sklearn_extra *py
               # ensure there is no unused imports with flake8
-              flake8 --select=F401
+              flake8
 
 workflows:
   version: 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+    -   id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
+    -   id: flake8
+        types: [file, python]

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -37,7 +37,12 @@ This is still a very young project, but we do have a few guiding principles:
 2. Write detailed docstrings in numpy format
 3. Support pandas dataframes and numpy arrays as inputs
 4. Write tests
-5. Format with black
+5. Format with black. You can use `pre-commit <https://pre-commit.com/>`_ to auto-format code on each commit,
+
+   .. code-block:: console
+
+       pip install pre-commit
+       pre-commit install
 
 Running Tests
 ^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ test = pytest
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 addopts = --doctest-modules
+
+[flake8]
+select = F401


### PR DESCRIPTION
This adds the [pre-commit](https://pre-commit.com/) setup, to auto apply linters (including black) on each commit. Use is optional.

Can be installed with,
```py
pip install pre-commit
pre-commit install  #(inside the repo)
```