### PR TITLE
FIX doc: change deprecated add_javascript to add_js_file

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -334,4 +334,4 @@ sphinx_gallery_conf = {
 
 def setup(app):
     # a copy button to copy snippet of code from the documentation
-    app.add_javascript("js/copybutton.js")
+    app.add_js_file("js/copybutton.js")


### PR DESCRIPTION
With the new version of sphinx, `add_javascript` does not exist anymore and must be replaced by `add_js_file`