### PR TITLE
Add float32 compatibility to KMedoids

### DIFF
--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -185,7 +185,9 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         random_state_ = check_random_state(self.random_state)
 
         self._check_init_args()
-        X = check_array(X, accept_sparse=["csr", "csc"])
+        X = check_array(
+            X, accept_sparse=["csr", "csc"], dtype=[np.float64, np.float32]
+        )
         if self.n_clusters > X.shape[0]:
             raise ValueError(
                 "The number of medoids (%d) must be less "
@@ -315,7 +317,9 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         X_new : {array-like, sparse matrix}, shape=(n_query, n_clusters)
             X transformed in the new space of distances to cluster centers.
         """
-        X = check_array(X, accept_sparse=["csr", "csc"])
+        X = check_array(
+            X, accept_sparse=["csr", "csc"], dtype=[np.float64, np.float32]
+        )
 
         if self.metric == "precomputed":
             check_is_fitted(self, "medoid_indices_")
@@ -345,7 +349,9 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         labels : array, shape = (n_query,)
             Index of the cluster each sample belongs to.
         """
-        X = check_array(X, accept_sparse=["csr", "csc"])
+        X = check_array(
+            X, accept_sparse=["csr", "csc"], dtype=[np.float64, np.float32]
+        )
 
         if self.metric == "precomputed":
             check_is_fitted(self, "medoid_indices_")

--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -94,8 +94,8 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
     >>> kmedoids.predict([[0,0], [4,4]])
     array([0, 1])
     >>> kmedoids.cluster_centers_
-    array([[1, 2],
-           [4, 2]])
+    array([[1., 2.],
+           [4., 2.]])
     >>> kmedoids.inertia_
     8.0
 

--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -152,7 +152,7 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
             )
 
     def _check_init_args(self):
-        """Validates the input arguments. """
+        """Validates the input arguments."""
 
         # Check n_clusters and max_iter
         self._check_nonnegative_int(self.n_clusters, "n_clusters")
@@ -300,7 +300,7 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
                 medoid_idxs[k] = cluster_k_idxs[min_cost_idx]
 
     def _compute_cost(self, D, medoid_idxs):
-        """ Compute the cose for a given configuration of the medoids"""
+        """Compute the cose for a given configuration of the medoids"""
         return self._compute_inertia(D[:, medoid_idxs])
 
     def transform(self, X):

--- a/sklearn_extra/cluster/tests/test_k_medoids.py
+++ b/sklearn_extra/cluster/tests/test_k_medoids.py
@@ -34,15 +34,17 @@ X_cc, y_cc = make_blobs(
 @pytest.mark.parametrize(
     "init", ["random", "heuristic", "build", "k-medoids++"]
 )
-def test_kmedoid_results(method, init):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_kmedoid_results(method, init, dtype):
     expected = np.hstack([np.zeros(50), np.ones(50)])
     km = KMedoids(n_clusters=2, init=init, method=method, random_state=rng)
-    km.fit(X_cc)
+    km.fit(X_cc.astype(dtype))
     # This test use data that are not perfectly separable so the
     # accuracy is not 1. Accuracy around 0.85
     assert (np.mean(km.labels_ == expected) > 0.8) or (
         1 - np.mean(km.labels_ == expected) > 0.8
     )
+    assert dtype is np.dtype(km.cluster_centers_.dtype).type
 
 
 def test_medoids_invalid_method():

--- a/sklearn_extra/cluster/tests/test_k_medoids.py
+++ b/sklearn_extra/cluster/tests/test_k_medoids.py
@@ -45,6 +45,7 @@ def test_kmedoid_results(method, init, dtype):
         1 - np.mean(km.labels_ == expected) > 0.8
     )
     assert dtype is np.dtype(km.cluster_centers_.dtype).type
+    assert dtype is np.dtype(km.transform(X_cc.astype(dtype)).dtype).type
 
 
 def test_medoids_invalid_method():

--- a/sklearn_extra/kernel_approximation/_fastfood.py
+++ b/sklearn_extra/kernel_approximation/_fastfood.py
@@ -116,7 +116,7 @@ class Fastfood(BaseEstimator, TransformerMixin):
             return None
 
     def _apply_approximate_gaussian_matrix(self, B, G, P, X):
-        """ Create mapping of all x_i by applying B, G and P step-wise """
+        """Create mapping of all x_i by applying B, G and P step-wise"""
         num_examples = X.shape[0]
 
         result = np.multiply(B, X.reshape((1, num_examples, 1, self._d)))
@@ -134,7 +134,7 @@ class Fastfood(BaseEstimator, TransformerMixin):
         return result
 
     def _scale_transformed_data(self, S, VX):
-        """ Scale mapped data VX to match kernel(e.g. RBF-Kernel) """
+        """Scale mapped data VX to match kernel(e.g. RBF-Kernel)"""
         VX = VX.reshape(-1, self._times_to_stack_v * self._d)
 
         return (

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -418,7 +418,7 @@ class _RobustWeightedEstimator(BaseEstimator):
         return self
 
     def _get_loss_function(self, loss):
-        """Get concrete ''LossFunction'' object for str ''loss''. """
+        """Get concrete ''LossFunction'' object for str ''loss''."""
         if type(loss) == str:
             eff_loss = LOSS_FUNCTIONS.get(loss)
             if eff_loss is None:


### PR DESCRIPTION
I implemented the changes suggested by @rth in PR#83 for dtypes in kmedoids.
In Clara, the dtype changes can make a consequent speedup but for kmedoids, I don't know why but there is no speedup:

Here is a small benchmark :

* KMedoids

|                            |   wall_time |   cpu_time |   peak_memory |
|:---------------------------|------------:|-----------:|--------------:|
| ('build', 'float32')       |   0.178639  |   0.49873  |    1.14062    |
| ('build', 'float64')       |   0.166929  |   0.396058 |    0.0859375  |
| ('heuristic', 'float32')   |   0.0497368 |   0.255722 |    0.0117188  |
| ('heuristic', 'float64')   |   0.0783268 |   0.250505 |   60.8164     |
| ('k-medoids++', 'float32') |   0.0602323 |   0.261578 |    0.00390625 |
| ('k-medoids++', 'float64') |   0.0871284 |   0.284815 |   61.0117     |


* CLARA

|                            |   wall_time |   cpu_time |   peak_memory |
|:---------------------------|------------:|-----------:|--------------:|
| ('build', 'float32')       |    0.944996 |    3.84636 |    0.160156   |
| ('build', 'float64')       |    0.794827 |    5.21157 |    1.21875    |
| ('heuristic', 'float32')   |    0.956299 |    4.54045 |    0          |
| ('heuristic', 'float64')   |    0.803466 |    5.22568 |    0          |
| ('k-medoids++', 'float32') |    0.940615 |    6.23457 |    0          |
| ('k-medoids++', 'float64') |    1.14663  |    6.11493 |    0.00390625 |




For Clara we can design settings in which the difference between 64 and 32 bit is quite large. Here I used n_sample = 200 000  in dimension 100 for CLARA and sampling_size = 200 . I used n_sample = 2000 for KMedoids.



<details>
<summary> Code </summary>

```
import numpy as np
import neurtu
from sklearn_extra.cluster import KMedoids, CLARA

X = np.random.normal(size=(100_000, 100))
X_32 = X.astype(np.float32)

def make_experiment(dtype, init):
    if dtype == 'float32':
        X2 = X_32
    else:
        X2 = X
    #km = CLARA(init=init, sampling_size= 50, n_clusters=9)
    km = KMedoids(n_clusters = 9, init = init)
    km.fit(X2)


def cases():
    for init in ['build', "heuristic", "k-medoids++"]:
        for dtype in ['float32', 'float64']:
            tags = {'init' : init, "dtype": dtype}
            yield neurtu.delayed(make_experiment, tags=tags)(dtype, init)
        
        
bench = neurtu.Benchmark(wall_time=True, cpu_time=True, peak_memory=True)
df = bench(cases()) # 2
```
</details>
