### PR TITLE
Add robust metric

### DIFF
--- a/sklearn_extra/robust/__init__.py
+++ b/sklearn_extra/robust/__init__.py
@@ -3,9 +3,12 @@ from sklearn_extra.robust.robust_weighted_estimator import (
     RobustWeightedKMeans,
     RobustWeightedRegressor,
 )
+from sklearn_extra.robust.mean_estimators import huber, make_huber_metric
 
 __all__ = [
     "RobustWeightedClassifier",
     "RobustWeightedKMeans",
     "RobustWeightedRegressor",
+    "huber",
+    "make_huber_metric",
 ]

--- a/sklearn_extra/robust/mean_estimators.py
+++ b/sklearn_extra/robust/mean_estimators.py
@@ -4,6 +4,7 @@
 # License: BSD 3 clause
 
 import numpy as np
+from scipy.stats import iqr
 
 
 def block_mom(X, k, random_state):
@@ -136,3 +137,26 @@ def huber(X, c=1.35, T=20):
         # new weights.
         mu = np.sum(np.array(w[ind_pos]) * x[ind_pos]) / np.sum(w[ind_pos])
     return mu
+
+
+def make_huber_metric(metric_func, c=None, T=20):
+    """
+    Make a robust metric using Huber estimator.
+    """
+
+    def metric(y_true, y_pred):
+        # change size in order to use the raw multisample
+        # to have individual values
+        y1 = [y_true]
+        y2 = [y_pred]
+        values = metric_func(y1, y2, multioutput="raw_values")
+        if c is None:
+            c_ = iqr(values)
+        else:
+            c_ = c
+        if c_ == 0:
+            return np.median(values)
+        else:
+            return huber(values, c_, T)
+
+    return metric

--- a/sklearn_extra/robust/tests/test_mean_estimators.py
+++ b/sklearn_extra/robust/tests/test_mean_estimators.py
@@ -1,7 +1,12 @@
 import numpy as np
 import pytest
 
-from sklearn_extra.robust.mean_estimators import median_of_means, huber
+from sklearn_extra.robust.mean_estimators import (
+    median_of_means,
+    huber,
+    make_huber_metric,
+)
+from sklearn.metrics import mean_squared_error
 
 
 rng = np.random.RandomState(42)
@@ -29,3 +34,12 @@ def test_huber():
     with pytest.warns(None) as record:
         huber(X)
     assert len(record) == 0
+
+
+def test_robust_metric():
+    robust_mse = make_huber_metric(mean_squared_error, c=5)
+    y_true = np.hstack([np.zeros(95), 20 * np.ones(5)])
+    np.random.shuffle(y_true)
+    y_pred = np.zeros(100)
+
+    assert robust_mse(y_true, y_pred) < 1


### PR DESCRIPTION
This PR use Huber robust mean estimator to make a robust metric. 

**Description:** one of the big challenge of robust machine learning is that the usual scoring scheme (cross_validation with MSE for instance)  is not robust. Indeed, if the dataset has some outliers, then the test sets in cross_validation may have outliers and then the cross_validation MSE would give us a huge error for our robust algorithm  on any corrupted data. This is why for example robust methods cannot be efficient for regression challenges in kaggle, because the error computation is not robust.
This PR propose a robust metric that would allow us to compute a robust cross-validation MSE for instance.


Example : 
```
import numpy as np
from sklearn.metrics import mean_squared_error
from sklearn_extra.robust import make_huber_metric

robust_mse = make_huber_metric(mean_squared_error, c=9) 
# c = 9 -> more than 99% of a normal is within [-3, 3]. Hence more that 99% of a normal squared is within [0,9].

y_true = np.random.normal(size=100)
y_true_cor = y_true.copy()
y_true_cor[42] = 20 # this is an outlier in the test set
y_pred = np.random.normal(size=100)


print('MSE on uncorrupted : %.3F ' %(mean_squared_error(y_true, y_pred)))
print('Robust MSE on uncorrupted : %.3F ' %(robust_mse(y_true, y_pred)))
print('MSE on corrupted : %.3F ' %(mean_squared_error(y_true_cor, y_pred)))
print('Robust MSE on corrupted : %.3F ' %(robust_mse(y_true_cor, y_pred)))
```

This returns 

```
MSE on uncorrupted : 2.152 
Robust MSE on uncorrupted : 2.072 
MSE on corrupted : 7.202 
Robust MSE on corrupted : 2.072 
```

TODO : add more explanations in the doc.
