### PR TITLE
Fix compatibility with latest version of scikit-learn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,8 @@ Dependencies
 
 scikit-learn-extra requires,
 
-- Python (>=3.6)
-- scikit-learn (>=0.23), and its dependencies
+- Python (>=3.7)
+- scikit-learn (>=0.24), and its dependencies
 
 
 Installation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,16 +5,11 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
-        NUMPY_VERSION: "1.13.3"
-        SCIPY_VERSION: "0.19.1"
-        SKLEARN_VERSION: "0.23.0"
       Python37:
         python.version: '3.7'
         NUMPY_VERSION: "1.16.5"
         SCIPY_VERSION: "1.1.0"
-        SKLEARN_VERSION: "0.23.2"
+        SKLEARN_VERSION: "0.24.1"
       Python38:
         python.version: '3.8'
         NUMPY_VERSION: "1.19.4"
@@ -25,6 +20,12 @@ jobs:
         NUMPY_VERSION: "1.19.4"
         SCIPY_VERSION: "1.5.4"
         SKLEARN_VERSION: "nightly"
+      Scikit_1:
+        python.version: '3.9'
+        NUMPY_VERSION: "1.19.4"
+        SCIPY_VERSION: "1.5.4"
+        SKLEARN_VERSION: "1.0.0"
+
   variables:
     OMP_NUM_THREADS: '2'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
         NUMPY_VERSION: "1.19.4"
         SCIPY_VERSION: "1.5.4"
         SKLEARN_VERSION: "nightly"
-      Scikit_1:
+      Py39_sklearn1:
         python.version: '3.9'
         NUMPY_VERSION: "1.19.4"
         SCIPY_VERSION: "1.5.4"
@@ -79,7 +79,7 @@ jobs:
       Python38:
         python.version: '3.8'
         SKLEARN_VERSION: "*"
-      Scikit_1:
+      Py39_sklearn1:
         python.version: '3.9'
         NUMPY_VERSION: "1.19.4"
         SCIPY_VERSION: "1.5.4"
@@ -133,7 +133,7 @@ jobs:
         NUMPY_VERSION: "1.18.2"
         SCIPY_VERSION: "1.4.1"
         SKLEARN_VERSION: "0.24.1"
-      Scikit_1:
+      Py39_sklearn1:
         python.version: '3.9'
         NUMPY_VERSION: "1.19.4"
         SCIPY_VERSION: "1.5.4"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,11 +71,6 @@ jobs:
     vmImage: 'macOS-10.14'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
-        NUMPY_VERSION: "1.13.3"
-        SCIPY_VERSION: "0.19.1"
-        SKLEARN_VERSION: "0.23.2"
       Python37:
         python.version: '3.7'
         NUMPY_VERSION: "1.16.5"
@@ -84,6 +79,11 @@ jobs:
       Python38:
         python.version: '3.8'
         SKLEARN_VERSION: "*"
+      Scikit_1:
+        python.version: '3.9'
+        NUMPY_VERSION: "1.19.4"
+        SCIPY_VERSION: "1.5.4"
+        SKLEARN_VERSION: "1.0.0"
   variables:
     OMP_NUM_THREADS: '2'
 
@@ -127,18 +127,18 @@ jobs:
     vmImage: 'vs2017-win2016'
   strategy:
     matrix:
-      Python36:
-        python_ver: '36'
-        python.version: '3.6'
-        NUMPY_VERSION: "1.13.3"
-        SCIPY_VERSION: "1.0.1"
-        SKLEARN_VERSION: "0.23.2"
       Python38:
         python_ver: '38'
         python.version: '3.8'
         NUMPY_VERSION: "1.18.2"
         SCIPY_VERSION: "1.4.1"
         SKLEARN_VERSION: "0.24.1"
+      Scikit_1:
+        python.version: '3.9'
+        NUMPY_VERSION: "1.19.4"
+        SCIPY_VERSION: "1.5.4"
+        SKLEARN_VERSION: "1.0.0"
+
   variables:
     OMP_NUM_THREADS: '2'
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,9 +5,9 @@ Dependencies
 ^^^^^^^^^^^^
 
 scikit-learn-extra requires,
- 
-- Python (>=3.6)
-- scikit-learn (>=0.23), and its dependencies
+
+- Python (>=3.7)
+- scikit-learn (>=0.24), and its dependencies
 
 
 User installation
@@ -22,7 +22,7 @@ Latest release can be installed with conda,
 or from PyPi with,
 
 .. code::
-   
+
    pip install scikit-learn-extra
 
 Latest development version can be installed with,

--- a/examples/cluster/plot_clustering.py
+++ b/examples/cluster/plot_clustering.py
@@ -76,7 +76,7 @@ for n_samples in [300, 600]:
         k=int(n_samples / 20),
         random_state=rng,
     )
-    bandwidth = cluster.estimate_bandwidth(X, 0.2)
+    bandwidth = cluster.estimate_bandwidth(X, quantile=0.2)
 
     ms = cluster.MeanShift(bandwidth=bandwidth, bin_seeding=True)
 

--- a/sklearn_extra/kernel_approximation/_fastfood.py
+++ b/sklearn_extra/kernel_approximation/_fastfood.py
@@ -201,6 +201,7 @@ class Fastfood(BaseEstimator, TransformerMixin):
         )
 
         self._U = self._uniform_vector(rng)
+        self.is_fitted_ = True
 
         return self
 

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -50,6 +50,7 @@ LOSS_FUNCTIONS = {
     "hinge": (Hinge,),
     "log": (Log,),
     "squared_error": (SquaredLoss,),
+    "squared_loss": (SquaredLoss,),
     "squared_hinge": (SquaredHinge,),
     "modified_huber": (ModifiedHuber,),
     "huber": (Huber, 1.35),  # 1.35 is default value. TODO : set as parameter
@@ -270,7 +271,7 @@ class _RobustWeightedEstimator(BaseEstimator):
         if "warm_start" in parameters:
             base_estimator.set_params(warm_start=True)
 
-        if "loss" in parameters:
+        if ("loss" in parameters) and (loss_param != "squared_error"):
             base_estimator.set_params(loss=loss_param)
 
         if "eta0" in parameters:

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -59,7 +59,7 @@ LOSS_FUNCTIONS = {
 # Test version of sklearn, in version older than v1.0 squared_loss must be used
 import sklearn
 
-if sklearn.__version__[0] == 0:
+if sklearn.__version__[0] == "0":
     SQ_LOSS = "squared_loss"
 else:
     SQ_LOSS = "squared_error"

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -56,6 +56,14 @@ LOSS_FUNCTIONS = {
     "huber": (Huber, 1.35),  # 1.35 is default value. TODO : set as parameter
 }
 
+# Test version of sklearn, in version older than v1.0 squared_loss must be used
+import sklearn
+
+if sklearn.__version__[0] == 0:
+    SQ_LOSS = "squared_loss"
+else:
+    SQ_LOSS = "squared_error"
+
 
 def _huber_psisx(x, c):
     """Huber-loss weight for RobustWeightedEstimator algorithm"""
@@ -1058,7 +1066,7 @@ class RobustWeightedRegressor(BaseEstimator, RegressorMixin):
         eta0=0.01,
         c=None,
         k=0,
-        loss="squared_error",
+        loss=SQ_LOSS,
         sgd_args=None,
         tol=1e-3,
         n_iter_no_change=10,

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -49,7 +49,7 @@ from ._robust_weighted_estimator_helper import (
 LOSS_FUNCTIONS = {
     "hinge": (Hinge,),
     "log": (Log,),
-    "squared_loss": (SquaredLoss,),
+    "squared_error": (SquaredLoss,),
     "squared_hinge": (SquaredHinge,),
     "modified_huber": (ModifiedHuber,),
     "huber": (Huber, 1.35),  # 1.35 is default value. TODO : set as parameter
@@ -107,7 +107,7 @@ class _RobustWeightedEstimator(BaseEstimator):
         base_estimator.
         Classification losses supported : 'log', 'hinge', 'squared_hinge',
         'modified_huber'. If 'log', then the base_estimator must support
-        predict_proba. Regression losses supported : 'squared_loss', 'huber'.
+        predict_proba. Regression losses supported : 'squared_error', 'huber'.
         If callable, the function is used as loss function ro construct
         the weights.
 
@@ -971,8 +971,8 @@ class RobustWeightedRegressor(BaseEstimator, RegressorMixin):
         (using the inter-quartile range), this tends to be conservative
         (robust).
 
-    loss : string, None or callable, default="squared_loss"
-        For now, only "squared_loss" and "huber" are implemented.
+    loss : string, None or callable, default="squared_error"
+        For now, only "squared_error" and "huber" are implemented.
 
     sgd_args : dict, default={}
         arguments of the SGDClassifier base estimator.
@@ -1057,7 +1057,7 @@ class RobustWeightedRegressor(BaseEstimator, RegressorMixin):
         eta0=0.01,
         c=None,
         k=0,
-        loss="squared_loss",
+        loss="squared_error",
         sgd_args=None,
         tol=1e-3,
         n_iter_no_change=10,

--- a/sklearn_extra/robust/tests/test_robust_weighted_estimator.py
+++ b/sklearn_extra/robust/tests/test_robust_weighted_estimator.py
@@ -19,7 +19,7 @@ from sklearn.utils._testing import (
 # Test version of sklearn, in version older than v1.0 squared_loss must be used
 import sklearn
 
-if sklearn.__version__[0] == 0:
+if sklearn.__version__[0] == "0":
     SQ_LOSS = "squared_loss"
 else:
     SQ_LOSS = "squared_error"

--- a/sklearn_extra/robust/tests/test_robust_weighted_estimator.py
+++ b/sklearn_extra/robust/tests/test_robust_weighted_estimator.py
@@ -16,6 +16,13 @@ from sklearn.utils._testing import (
     assert_almost_equal,
 )
 
+# Test version of sklearn, in version older than v1.0 squared_loss must be used
+import sklearn
+
+if sklearn.__version__[0] == 0:
+    SQ_LOSS = "squared_loss"
+else:
+    SQ_LOSS = "squared_error"
 
 k_values = [None, 10]  # values of k for test robust
 c_values = [None, 1e-3]  # values of c for test robust
@@ -239,7 +246,7 @@ X_rc[0] = 10
 X_rc = X_rc.reshape(-1, 1)
 y_rc[0] = -1
 
-regression_losses = ["squared_error", "huber"]
+regression_losses = [SQ_LOSS, "huber"]
 
 
 @pytest.mark.parametrize("loss", regression_losses)

--- a/sklearn_extra/robust/tests/test_robust_weighted_estimator.py
+++ b/sklearn_extra/robust/tests/test_robust_weighted_estimator.py
@@ -239,7 +239,7 @@ X_rc[0] = 10
 X_rc = X_rc.reshape(-1, 1)
 y_rc[0] = -1
 
-regression_losses = ["squared_loss", "huber"]
+regression_losses = ["squared_error", "huber"]
 
 
 @pytest.mark.parametrize("loss", regression_losses)


### PR DESCRIPTION
New version of scikit-learn changed squared_loss to squared_error, I fixed this issue in RobustWeightedRegressor
New version of scikit-learn changed check_is_fitted common test that we also use and it failed for fastfood. 
There is also a parameter that changed for clustering bandwidth algo, need to be fixed in examples.