### PR TITLE
PEP632: Remove depracted call of distutils.version.LooseVersion

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 import sys
-from distutils.version import LooseVersion
+from packaging.version import Version
 import sklearn
 
 import pytest
@@ -14,9 +14,9 @@ def pytest_collection_modifyitems(config, items):
     try:
         import numpy as np
 
-        if LooseVersion(np.__version__) < LooseVersion("1.14") or LooseVersion(
+        if Version(np.__version__) < Version("1.14") or Version(
             sklearn.__version__
-        ) < LooseVersion("0.23.0"):
+        ) < Version("0.23.0"):
             reason = (
                 "doctests are only run for numpy >= 1.14 "
                 "and scikit-learn >=0.23.0"

--- a/sklearn_extra/cluster/_commonnn.py
+++ b/sklearn_extra/cluster/_commonnn.py
@@ -6,7 +6,7 @@
 #
 # License: BSD 3 clause
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 import warnings
 
 import numpy as np
@@ -15,7 +15,7 @@ from scipy import sparse
 import sklearn
 from sklearn.base import BaseEstimator, ClusterMixin
 
-if LooseVersion(sklearn.__version__) < LooseVersion("0.23.0"):
+if Version(sklearn.__version__) < Version("0.23.0"):
     from sklearn.utils import check_array, check_consistent_length
 
     # In scikit-learn version 0.23.x use


### PR DESCRIPTION
Remove the depracted call of `distutils.version.LooseVersion` with `packaging.version.Version`. The reason is that starting from Python 3.12 the `distutils` package will be removed, see [PEP634](https://peps.python.org/pep-0632/). In the `packaging` module there is no `LooseVersion`, but regarding the strict versioning of `sklearn` this should make no difference.