### PR TITLE
docs: Adds link to license in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,4 +55,4 @@ or from PyPi with,
 License
 -------
 
-This package is released under the 3-Clause BSD license.
+This package is released under the `3-Clause BSD license <https://github.com/scikit-learn-contrib/scikit-learn-extra/blob/main/LICENSE>`_.


### PR DESCRIPTION
Would resolve https://github.com/scikit-learn-contrib/scikit-learn-extra/issues/148 if merged