### PR TITLE
Expose Distance Information in KMedoids

### DIFF
--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -311,7 +311,15 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         # the training data to clusters
         self.labels_ = np.argmin(D[medoid_idxs, :], axis=0)
         self.medoid_indices_ = medoid_idxs
-        self.inertia_ = _compute_inertia(self.transform(X))
+
+        # Extra Addition
+        distances = self.transform(X)
+        self.distances_ = distances
+        
+        # Modification
+        self.inertia_ = _compute_inertia(distances) ## Prebiously this line was _compute_inertia(self.transform(X))
+        
+   
 
         # Return self to enable method chaining
         return self

--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -315,11 +315,11 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         # Extra Addition
         distances = self.transform(X)
         self.distances_ = distances
-        
+
         # Modification
-        self.inertia_ = _compute_inertia(distances) ## Prebiously this line was _compute_inertia(self.transform(X))
-        
-   
+        self.inertia_ = _compute_inertia(
+            distances
+        )  ## Prebiously this line was _compute_inertia(self.transform(X))
 
         # Return self to enable method chaining
         return self


### PR DESCRIPTION
### Description
This pull request enhances the KMedoids implementation by exposing the distances of data points to their respective medoids. Previously, this information was internally computed during the clustering process but not exposed to users. The addition of the distances_ attribute allows users to access these distances without the need for additional pairwise distance calculations, which can be computationally expensive.

### Changes Made
Addition of `distances_` Attribute:

A new attribute, `distances_`, has been introduced to store the distances of each data point to its assigned medoid.
Modification of fit Method:

The distances are now computed using the existing transform method and stored in the distances_ attribute.
The self.inertia_ attribute is updated to use the distances directly, avoiding redundant pairwise distance calculations.
### Motivation
The motivation behind this enhancement is to provide users with direct access to the distances between data points and their respective medoids. This information can be valuable for users who wish to perform additional statistical analyses, such as identifying the closest data points to medoids, without incurring the cost of recomputing pairwise distances.
### Example Usage
Users can now access the distances using the distances_ attribute after fitting the model:


```
kmedoids_model = KMedoids(n_clusters=3)
kmedoids_model.fit(data)
distances_to_medoids = kmedoids_model.distances_
```
This information can be utilized for various purposes, enhancing the flexibility and utility of the KMedoids implementation.