### PR TITLE
Add support for numpy 2

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,15 +25,14 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.12.1
+          python -m pip install cibuildwheel==2.16.5
       - name: Build wheels
         env:
-          # We only build for Python 3.6+. On Linux manylinux2010 is used.
           # Skipping pypy wheels for now since scipy & scikit-learn haven't build them yet.
-          # Skip python3.11 for 32bit.
+          # 32bit Windows, i686 Linux and musllinux are also skipped.
           CIBW_SKIP: "pp* *-win32 *-manylinux_i686 *musllinux*"
           CIBW_TEST_REQUIRES: "pytest pandas scikit-learn"
           CIBW_TEST_COMMAND: "pytest --pyargs sklearn_extra"
@@ -52,7 +51,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: pip install setuptools cython numpy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
     -   id: flake8
         types: [file, python]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,11 @@ jobs:
         NUMPY_VERSION: "*"
         SCIPY_VERSION: "*"
         SKLEARN_VERSION: "*"
+      Python312:
+        python.version: '3.12'
+        NUMPY_VERSION: "*"
+        SCIPY_VERSION: "*"
+        SKLEARN_VERSION: "*"
 
   variables:
     OMP_NUM_THREADS: '2'
@@ -76,6 +81,11 @@ jobs:
         NUMPY_VERSION: "*"
         SCIPY_VERSION: "*"
         SKLEARN_VERSION: "*"
+      Python312:
+        python.version: '3.12'
+        NUMPY_VERSION: "*"
+        SCIPY_VERSION: "*"
+        SKLEARN_VERSION: "*"
   variables:
     OMP_NUM_THREADS: '2'
 
@@ -126,6 +136,11 @@ jobs:
         SKLEARN_VERSION: "1.4.2"
       Python311:
         python.version: '3.11'
+        NUMPY_VERSION: "2.0.2"
+        SCIPY_VERSION: "1.13.1"
+        SKLEARN_VERSION: "1.4.2"
+      Python312:
+        python.version: '3.12'
         NUMPY_VERSION: "2.0.2"
         SCIPY_VERSION: "1.13.1"
         SKLEARN_VERSION: "1.4.2"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,18 +7,18 @@ jobs:
     matrix:
       Python39:
         python.version: '3.9'
-        NUMPY_VERSION: "1.19.4"
-        SCIPY_VERSION: "1.5.4"
-        SKLEARN_VERSION: "*"
+        NUMPY_VERSION: "1.22.4"
+        SCIPY_VERSION: "1.13.1"
+        SKLEARN_VERSION: "1.4.2"
       Python310:
         python.version: '3.10'
-        NUMPY_VERSION: "1.26.1"
-        SCIPY_VERSION: "1.11.3"
-        SKLEARN_VERSION: "*"
+        NUMPY_VERSION: "2.0.2"
+        SCIPY_VERSION: "1.13.1"
+        SKLEARN_VERSION: "1.4.2"
       Python311:
-        python.version: '3.10'
-        NUMPY_VERSION: "1.26.1"
-        SCIPY_VERSION: "1.11.3"
+        python.version: '3.11'
+        NUMPY_VERSION: "*"
+        SCIPY_VERSION: "*"
         SKLEARN_VERSION: "*"
 
   variables:
@@ -68,13 +68,13 @@ jobs:
     matrix:
       Python310:
         python.version: '3.10'
-        NUMPY_VERSION: "1.26.1"
-        SCIPY_VERSION: "1.11.3"
-        SKLEARN_VERSION: "*"
+        NUMPY_VERSION: "2.0.2"
+        SCIPY_VERSION: "1.13.1"
+        SKLEARN_VERSION: "1.4.2"
       Python311:
-        python.version: '3.10'
-        NUMPY_VERSION: "1.26.1"
-        SCIPY_VERSION: "1.11.3"
+        python.version: '3.11'
+        NUMPY_VERSION: "*"
+        SCIPY_VERSION: "*"
         SKLEARN_VERSION: "*"
   variables:
     OMP_NUM_THREADS: '2'
@@ -121,14 +121,14 @@ jobs:
     matrix:
       Python310:
         python.version: '3.10'
-        NUMPY_VERSION: "1.26.1"
-        SCIPY_VERSION: "1.11.3"
-        SKLEARN_VERSION: "1.3.2"
+        NUMPY_VERSION: "1.26.4"
+        SCIPY_VERSION: "1.13.1"
+        SKLEARN_VERSION: "1.4.2"
       Python311:
-        python.version: '3.10'
-        NUMPY_VERSION: "1.26.1"
-        SCIPY_VERSION: "1.11.3"
-        SKLEARN_VERSION: "1.3.2"
+        python.version: '3.11'
+        NUMPY_VERSION: "2.0.2"
+        SCIPY_VERSION: "1.13.1"
+        SKLEARN_VERSION: "1.4.2"
 
   variables:
     OMP_NUM_THREADS: '2'

--- a/examples/robust/plot_robust_classification_diabete.py
+++ b/examples/robust/plot_robust_classification_diabete.py
@@ -21,7 +21,9 @@ import warnings
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
-X, y = fetch_openml(name="diabetes", as_frame=False, return_X_y=True)
+X, y = fetch_openml(
+    name="diabetes", as_frame=False, return_X_y=True, parser="liac-arff"
+)
 
 # replace the label names with 0 or 1
 y = (y == "tested_positive").astype(int)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,11 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.28.5",
+    # 3.0.10 is the first Cython release that supports the numpy 2 C API
+    "Cython>=3.0.10",
 
-    # use oldest-supported-numpy which provides the oldest numpy version with
-    # wheels on PyPI
-    #
-    # see: https://github.com/scipy/oldest-supported-numpy/blob/master/setup.cfg
-    "oldest-supported-numpy"
+    # Build against numpy 2.0 for ABI compatibility with both numpy 1.x and 2.x
+    "numpy>=2.0,<3",
 ]
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,11 @@ LICENSE = "new BSD"
 DOWNLOAD_URL = "https://github.com/scikit-learn-contrib/scikit-learn-extra"
 VERSION = __version__  # noqa
 INSTALL_REQUIRES = [
-    "numpy>=1.13.3",
-    "scipy>=0.19.1",
-    "scikit-learn>=0.23.0",
+    # 1.22.4 is the oldest numpy compatible with numpy 2 builds and scipy>=1.13.1.
+    "numpy>=1.22.4",
+    # First scipy and scikit-learn releases with numpy 2 support.
+    "scipy>=1.13.1",
+    "scikit-learn>=1.4.2",
     "packaging",
 ]
 CLASSIFIERS = [
@@ -38,10 +40,10 @@ CLASSIFIERS = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 EXTRAS_REQUIRE = {
@@ -59,6 +61,10 @@ libraries = []
 if os.name == "posix":
     libraries.append("m")
 
+# Target the numpy C-API level matching the numpy floor in INSTALL_REQUIRES,
+# so it does not drift with the numpy version used to build.
+define_macros = [("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION")]
+
 args = {
     "ext_modules": cythonize(
         [
@@ -66,22 +72,26 @@ args = {
                 "sklearn_extra.utils._cyfht",
                 ["sklearn_extra/utils/_cyfht.pyx"],
                 include_dirs=[np.get_include()],
+                define_macros=define_macros,
             ),
             Extension(
                 "sklearn_extra.cluster._k_medoids_helper",
                 ["sklearn_extra/cluster/_k_medoids_helper.pyx"],
                 include_dirs=[np.get_include()],
+                define_macros=define_macros,
             ),
             Extension(
                 "sklearn_extra.robust._robust_weighted_estimator_helper",
                 ["sklearn_extra/robust/_robust_weighted_estimator_helper.pyx"],
                 include_dirs=[np.get_include()],
+                define_macros=define_macros,
                 libraries=libraries,
             ),
             Extension(
                 "sklearn_extra.cluster._commonnn_inner",
                 ["sklearn_extra/cluster/_commonnn_inner.pyx"],
                 include_dirs=[np.get_include()],
+                define_macros=define_macros,
                 language="c++",
             ),
         ]
@@ -104,6 +114,6 @@ setup(
     packages=find_packages(),
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
-    python_requires=">=3.6",
-    **args
+    python_requires=">=3.9",
+    **args,
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ INSTALL_REQUIRES = [
     "numpy>=1.22.4",
     # First scipy and scikit-learn releases with numpy 2 support.
     "scipy>=1.13.1",
-    "scikit-learn>=1.4.2",
+    "scikit-learn>=1.4.2,<2",
     "packaging",
 ]
 CLASSIFIERS = [

--- a/sklearn_extra/_compat.py
+++ b/sklearn_extra/_compat.py
@@ -1,0 +1,19 @@
+try:
+    from sklearn.utils.validation import validate_data
+except ImportError:
+
+    def validate_data(estimator, *args, **kwargs):
+        return estimator._validate_data(*args, **kwargs)
+
+
+try:
+    from sklearn.utils import get_tags
+except ImportError:
+
+    def estimator_type(estimator):
+        return estimator._estimator_type
+
+else:
+
+    def estimator_type(estimator):
+        return get_tags(estimator).estimator_type

--- a/sklearn_extra/cluster/_commonnn.py
+++ b/sklearn_extra/cluster/_commonnn.py
@@ -28,6 +28,7 @@ else:
 
 from sklearn.neighbors import NearestNeighbors
 
+from .._compat import validate_data
 from ._commonnn_inner import commonnn_inner
 
 
@@ -269,6 +270,14 @@ class CommonNNClustering(ClusterMixin, BaseEstimator):
     # TODO Use
     # @_deprecate_positional_args
     #     not in scikit-learn version 0.21.3
+    def _more_tags(self):
+        return {"X_types": ["2darray", "sparse"]}
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
+
     def __init__(
         self,
         eps=0.5,
@@ -320,7 +329,7 @@ class CommonNNClustering(ClusterMixin, BaseEstimator):
         if Version(sklearn.__version__) < Version("0.23.0"):
             X = check_array(X, accept_sparse="csr")
         else:
-            X = self._validate_data(X, accept_sparse="csr")
+            X = validate_data(self, X, accept_sparse="csr")
 
         if not self.eps > 0.0:
             raise ValueError("eps must be positive.")

--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -120,7 +120,7 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
     >>> kmedoids.cluster_centers_
     array([[1., 2.],
            [4., 2.]])
-    >>> kmedoids.inertia_
+    >>> float(kmedoids.inertia_)
     8.0
 
     See scikit-learn-extra/examples/plot_kmedoids_digits.py for examples
@@ -594,7 +594,7 @@ class CLARA(BaseEstimator, ClusterMixin, TransformerMixin):
     >>> clara = CLARA(n_clusters=2, random_state=0).fit(X)
     >>> clara.predict([[0,0], [4,4]])
     array([0, 1])
-    >>> clara.inertia_
+    >>> float(clara.inertia_)
     122.44919397611667
 
     References

--- a/sklearn_extra/cluster/_k_medoids.py
+++ b/sklearn_extra/cluster/_k_medoids.py
@@ -15,10 +15,12 @@ from sklearn.metrics.pairwise import (
     pairwise_distances,
     pairwise_distances_argmin,
 )
-from sklearn.utils import check_array, check_random_state
+from sklearn.utils import check_random_state
 from sklearn.utils.extmath import stable_cumsum
 from sklearn.utils.validation import check_is_fitted
 from sklearn.exceptions import ConvergenceWarning
+
+from .._compat import validate_data
 
 # cython implementation of steps in PAM algorithm.
 from ._k_medoids_helper import _compute_optimal_swap, _build
@@ -45,7 +47,7 @@ def _compute_inertia(distances):
     return inertia
 
 
-class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
+class KMedoids(ClusterMixin, TransformerMixin, BaseEstimator):
     """k-medoids clustering.
 
     Read more in the :ref:`User Guide <k_medoids>`.
@@ -147,6 +149,14 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
 
     """
 
+    def _more_tags(self):
+        return {"X_types": ["2darray", "sparse"]}
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
+
     def __init__(
         self,
         n_clusters=8,
@@ -225,10 +235,12 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         random_state_ = check_random_state(self.random_state)
 
         self._check_init_args()
-        X = check_array(
-            X, accept_sparse=["csr", "csc"], dtype=[np.float64, np.float32]
+        X = validate_data(
+            self,
+            X,
+            accept_sparse=["csr", "csc"],
+            dtype=[np.float64, np.float32],
         )
-        self.n_features_in_ = X.shape[1]
         if self.n_clusters > X.shape[0]:
             raise ValueError(
                 "The number of medoids (%d) must be less "
@@ -369,8 +381,12 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         X_new : {array-like, sparse matrix}, shape=(n_query, n_clusters)
             X transformed in the new space of distances to cluster centers.
         """
-        X = check_array(
-            X, accept_sparse=["csr", "csc"], dtype=[np.float64, np.float32]
+        X = validate_data(
+            self,
+            X,
+            accept_sparse=["csr", "csc"],
+            dtype=[np.float64, np.float32],
+            reset=False,
         )
 
         if self.metric == "precomputed":
@@ -401,8 +417,12 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         labels : array, shape = (n_query,)
             Index of the cluster each sample belongs to.
         """
-        X = check_array(
-            X, accept_sparse=["csr", "csc"], dtype=[np.float64, np.float32]
+        X = validate_data(
+            self,
+            X,
+            accept_sparse=["csr", "csc"],
+            dtype=[np.float64, np.float32],
+            reset=False,
         )
 
         if self.metric == "precomputed":
@@ -537,7 +557,7 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         return centers
 
 
-class CLARA(BaseEstimator, ClusterMixin, TransformerMixin):
+class CLARA(ClusterMixin, TransformerMixin, BaseEstimator):
     """CLARA clustering.
 
     Read more in the :ref:`User Guide <CLARA>`.
@@ -650,8 +670,7 @@ class CLARA(BaseEstimator, ClusterMixin, TransformerMixin):
         -------
         self
         """
-        X = check_array(X, dtype=[np.float64, np.float32])
-        self.n_features_in_ = X.shape[1]
+        X = validate_data(self, X, dtype=[np.float64, np.float32])
 
         n = len(X)
 
@@ -731,8 +750,12 @@ class CLARA(BaseEstimator, ClusterMixin, TransformerMixin):
         X_new : {array-like, sparse matrix}, shape=(n_query, n_clusters)
             X transformed in the new space of distances to cluster centers.
         """
-        X = check_array(
-            X, accept_sparse=["csr", "csc"], dtype=[np.float64, np.float32]
+        X = validate_data(
+            self,
+            X,
+            accept_sparse=["csr", "csc"],
+            dtype=[np.float64, np.float32],
+            reset=False,
         )
 
         if self.metric == "precomputed":
@@ -758,8 +781,12 @@ class CLARA(BaseEstimator, ClusterMixin, TransformerMixin):
         labels : array, shape = (n_query,)
             Index of the cluster each sample belongs to.
         """
-        X = check_array(
-            X, accept_sparse=["csr", "csc"], dtype=[np.float64, np.float32]
+        X = validate_data(
+            self,
+            X,
+            accept_sparse=["csr", "csc"],
+            dtype=[np.float64, np.float32],
+            reset=False,
         )
 
         if self.metric == "precomputed":

--- a/sklearn_extra/cluster/tests/test_k_medoids.py
+++ b/sklearn_extra/cluster/tests/test_k_medoids.py
@@ -405,12 +405,13 @@ def test_clara_consistency_iris():
 
 
 def test_seuclidean():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         km = KMedoids(2, metric="seuclidean", method="pam")
         km.fit(np.array([0, 0, 0, 1]).reshape((4, 1)))
         km.predict(np.array([0, 0, 0, 1]).reshape((4, 1)))
         km.transform(np.array([0, 0, 0, 1]).reshape((4, 1)))
-    assert len(record) == 0
+    assert not record
 
 
 def test_medoids_indices():

--- a/sklearn_extra/kernel_approximation/_fastfood.py
+++ b/sklearn_extra/kernel_approximation/_fastfood.py
@@ -6,12 +6,13 @@ from scipy.stats import chi
 
 from sklearn.base import BaseEstimator
 from sklearn.base import TransformerMixin
-from sklearn.utils import check_array, check_random_state
+from sklearn.utils import check_random_state
 
+from .._compat import validate_data
 from ..utils._cyfht import fht2 as cyfht
 
 
-class Fastfood(BaseEstimator, TransformerMixin):
+class Fastfood(TransformerMixin, BaseEstimator):
     """Approximates feature map of an RBF kernel by Monte Carlo approximation
     of its Fourier transform.
 
@@ -167,8 +168,7 @@ class Fastfood(BaseEstimator, TransformerMixin):
         self : object
             Returns the transformer.
         """
-        X = check_array(X, order="C", dtype=np.float64)
-        self.n_features_in_ = X.shape[1]
+        X = validate_data(self, X, order="C", dtype=np.float64)
 
         d_orig = X.shape[1]
         rng = check_random_state(self.random_state)
@@ -219,7 +219,7 @@ class Fastfood(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape (n_samples, n_components)
         """
-        X = check_array(X, order="C", dtype=np.float64)
+        X = validate_data(self, X, order="C", dtype=np.float64, reset=False)
         X_padded = self._pad_with_zeros(X)
         HGPHBX = self._apply_approximate_gaussian_matrix(
             self._B, self._G, self._P, X_padded

--- a/sklearn_extra/kernel_methods/_eigenpro.py
+++ b/sklearn_extra/kernel_methods/_eigenpro.py
@@ -7,7 +7,9 @@ from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.metrics.pairwise import pairwise_kernels, euclidean_distances
 from sklearn.utils import check_random_state
 from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.validation import check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted
+
+from .._compat import validate_data
 
 
 class BaseEigenPro(BaseEstimator):
@@ -314,7 +316,8 @@ class BaseEigenPro(BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        X, Y = check_X_y(
+        X, Y = validate_data(
+            self,
             X,
             Y,
             dtype=np.float32,
@@ -322,7 +325,6 @@ class BaseEigenPro(BaseEstimator):
             ensure_min_samples=3,
             y_numeric=True,
         )
-        self.n_features_in_ = X.shape[1]
         Y = Y.astype(np.float32)
         random_state = check_random_state(self.random_state)
 
@@ -373,13 +375,7 @@ class BaseEigenPro(BaseEstimator):
         check_is_fitted(
             self, ["bs_", "centers_", "coef_", "was_1D_", "gamma_"]
         )
-        X = np.asarray(X, dtype=np.float64)
-
-        if len(X.shape) == 1:
-            raise ValueError(
-                "Reshape your data. X should be a matrix of shape"
-                " (n_samples, n_features)."
-            )
+        X = validate_data(self, X, dtype=np.float64, reset=False)
         n = X.shape[0]
 
         Ys = []
@@ -394,9 +390,12 @@ class BaseEigenPro(BaseEstimator):
             Y = np.reshape(Y, Y.shape[0])
         return Y
 
-    def _get_tags(self):
-        tags = super()._get_tags()
-        tags["multioutput"] = True
+    def _more_tags(self):
+        return {"multioutput": True}
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.target_tags.multi_output = True
         return tags
 
 
@@ -631,11 +630,11 @@ class EigenProClassifier(ClassifierMixin, BaseEigenPro):
         -------
         self : returns an instance of self.
         """
-        X, Y = check_X_y(
+        X, Y = validate_data(
+            self,
             X,
             Y,
             dtype=np.float32,
-            force_all_finite=True,
             multi_output=False,
             ensure_min_samples=3,
         )

--- a/sklearn_extra/kernel_methods/_eigenpro.py
+++ b/sklearn_extra/kernel_methods/_eigenpro.py
@@ -110,11 +110,11 @@ class BaseEigenPro(BaseEstimator):
 
         W = K / m
         try:
-            E, Lambda = eigh(W, eigvals=(m - n_components, m - 1))
+            E, Lambda = eigh(W, subset_by_index=(m - n_components, m - 1))
         except LinAlgError:
             # Use float64 when eigh fails due to precision
             W = np.float64(W)
-            E, Lambda = eigh(W, eigvals=(m - n_components, m - 1))
+            E, Lambda = eigh(W, subset_by_index=(m - n_components, m - 1))
             E, Lambda = np.float32(E), np.float32(Lambda)
         # Flip so eigenvalues are in descending order.
         E = np.maximum(np.float32(1e-7), np.flipud(E))

--- a/sklearn_extra/kernel_methods/tests/test_eigenpro.py
+++ b/sklearn_extra/kernel_methods/tests/test_eigenpro.py
@@ -31,7 +31,7 @@ def gen_classification(params):
 @pytest.mark.parametrize(
     "params, err_msg",
     [
-        ({"kernel": "not_a_kernel"}, "Unknown kernel 'not_a_kernel'"),
+        ({"kernel": "not_a_kernel"}, "not_a_kernel"),
         ({"n_epoch": 0}, "n_epoch should be positive, was 0"),
         ({"n_epoch": -1}, "n_epoch should be positive, was -1"),
         ({"n_components": -1}, "n_components should be non-negative, was -1"),

--- a/sklearn_extra/robust/_robust_weighted_estimator_helper.pyx
+++ b/sklearn_extra/robust/_robust_weighted_estimator_helper.pyx
@@ -15,7 +15,6 @@ from time import time
 
 from libc.math cimport exp, log, sqrt, pow, fabs
 cimport numpy as np
-from numpy.math cimport INFINITY
 
 
 # Modified from sklearn.cluster._k_means_fast.pyx
@@ -66,7 +65,8 @@ cpdef np.ndarray[floating] _kmeans_loss(np.ndarray[floating, ndim=2, mode='c'] X
         np.ndarray[floating, ndim=2] centers = np.zeros([n_classes,
                                                          n_features],
                                                          dtype = dtype)
-        np.ndarray[long] num_in_cluster = np.zeros(n_classes, dtype = int)
+        np.ndarray[np.npy_intp] num_in_cluster = np.zeros(n_classes,
+                                                          dtype = np.intp)
         np.ndarray[floating] inertias = np.zeros(n_samples, dtype = dtype)
     for i in range(n_samples):
         for j in range(n_features):

--- a/sklearn_extra/robust/robust_weighted_estimator.py
+++ b/sklearn_extra/robust/robust_weighted_estimator.py
@@ -14,6 +14,7 @@ from sklearn.base import (
     ClassifierMixin,
     RegressorMixin,
     ClusterMixin,
+    TransformerMixin,
 )
 from sklearn.utils import (
     check_random_state,
@@ -27,6 +28,8 @@ from sklearn.cluster import MiniBatchKMeans
 from sklearn.metrics.pairwise import euclidean_distances
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.metaestimators import available_if
+
+from .._compat import estimator_type, validate_data
 
 # Tool library in which we get robust mean estimators.
 from .mean_estimators import median_of_means_blocked, block_mom, huber
@@ -518,7 +521,7 @@ class _RobustWeightedEstimator(BaseEstimator):
 
     @property
     def _estimator_type(self):
-        return self.base_estimator._estimator_type
+        return estimator_type(self.base_estimator)
 
     def score(self, X, y=None):
         """Returns the score on the given data, using
@@ -561,7 +564,7 @@ class _RobustWeightedEstimator(BaseEstimator):
         return self.base_estimator_.decision_function(X)
 
 
-class RobustWeightedClassifier(BaseEstimator, ClassifierMixin):
+class RobustWeightedClassifier(ClassifierMixin, BaseEstimator):
     """Algorithm for robust classification using reweighting algorithm.
 
     This model uses iterative reweighting of samples to make a regression or
@@ -760,7 +763,7 @@ class RobustWeightedClassifier(BaseEstimator, ClassifierMixin):
             sgd_args = self.sgd_args
 
         # Define the base estimator
-        X, y = self._validate_data(X, y, y_numeric=False)
+        X, y = validate_data(self, X, y, y_numeric=False)
 
         base_robust_estimator_ = _RobustWeightedEstimator(
             SGDClassifier(**sgd_args),
@@ -878,7 +881,7 @@ class RobustWeightedClassifier(BaseEstimator, ClassifierMixin):
         return self.base_estimator_.decision_function(X)
 
 
-class RobustWeightedRegressor(BaseEstimator, RegressorMixin):
+class RobustWeightedRegressor(RegressorMixin, BaseEstimator):
     """Algorithm for robust regression using reweighting algorithm.
 
     This model uses iterative reweighting of samples to make a regression or
@@ -1055,7 +1058,7 @@ class RobustWeightedRegressor(BaseEstimator, RegressorMixin):
 
         # Define the base estimator
 
-        X, y = self._validate_data(X, y, y_numeric=True)
+        X, y = validate_data(self, X, y, y_numeric=True)
 
         self.base_estimator_ = _RobustWeightedEstimator(
             SGDRegressor(**sgd_args),
@@ -1113,7 +1116,7 @@ class RobustWeightedRegressor(BaseEstimator, RegressorMixin):
         return self.base_estimator_.score(X, y)
 
 
-class RobustWeightedKMeans(BaseEstimator, ClusterMixin):
+class RobustWeightedKMeans(ClusterMixin, TransformerMixin, BaseEstimator):
     """Algorithm for robust kmeans clustering using reweighting algorithm.
 
     This model uses iterative reweighting of samples to make a regression or
@@ -1291,7 +1294,8 @@ class RobustWeightedKMeans(BaseEstimator, ClusterMixin):
             kmeans_args = {}
         else:
             kmeans_args = self.kmeans_args
-        X = self._validate_data(
+        X = validate_data(
+            self,
             X,
             accept_sparse="csr",
             dtype=[np.float64, np.float32],
@@ -1376,7 +1380,7 @@ class RobustWeightedKMeans(BaseEstimator, ClusterMixin):
             X transformed in the new space.
         """
         check_is_fitted(self)
-
+        X = validate_data(self, X, accept_sparse="csr", reset=False)
         return self._transform(X)
 
     def _transform(self, X):

--- a/sklearn_extra/robust/tests/test_mean_estimators.py
+++ b/sklearn_extra/robust/tests/test_mean_estimators.py
@@ -1,5 +1,6 @@
+import warnings
+
 import numpy as np
-import pytest
 
 from sklearn_extra.robust.mean_estimators import median_of_means, huber
 
@@ -27,7 +28,8 @@ def test_mom():
 
 def test_huber():
     X = np.hstack([np.zeros(90), np.ones(10)])
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         mu = huber(X, c=0.5)
-    assert len(record) == 0
+    assert not record
     assert np.abs(mu) < 0.1


### PR DESCRIPTION
Update some library functions to use the numpy 2 compatible APIs, and raise the floor of several dependencies to enable this.

Numpy 2 supports building Cython extensions with 1.x compatibility, but this does raise the minimum supported versions:

- scipy 0.19.1 -> 1.13.1 -- the first scipy release for numpy 2
- scikit-learn 0.23.0 -> 1.4.2 -- the first sklearn release for numpy 2
- numpy 1.13.3 -> 1.22.4 -- numpy 2 builds are compatible down to 1.19, but scipy 1.13 requires numpy>=1.22.
- Cython 0.28.5 -> 3.0.10 -- required for the backwards-compatible numpy extension API
- Python 3.6 -> 3.9 -- new floor in scipy and sklearn updates

In response to these adjusted dependencies, this commit also updates some of the library code:

- Replace `scipy.linalg.eigh(eigvals=...)`, which was removed in scipy 1.12 with the equivalent `subset_by_index=...`
- Replace use of `long` data type with the more platform-agnostic `np.npy_intp` type.
- Remove the import of unused `numpy.math.INFINITY`
- Update comments in _k_medoids to reflect the new numpy return type